### PR TITLE
Fix/ typeParameter Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.2.0 (2020-06-04)
+
+
+### Features
+
+* **initial:** Initial config ([cd934df](https://github.com/barnpros/eslint-config-barnpros/commit/cd934df34acdc0ebc9e41e23600c93dc95a2c111))
+
+
+### Bug Fixes
+
+* **type parameter:** Removed array wrapping from typeParameter ([f00f5d1](https://github.com/barnpros/eslint-config-barnpros/commit/f00f5d101b6fe299a2eec73deaa7beddcbc530b1))
+
 ## 1.1.0 (2020-06-04)
 
 

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ module.exports = {
             suffix: ["Type"],
           },
           {
-            selector: ["typeParameter"],
+            selector: "typeParameter",
             format: ["PascalCase"],
             prefix: ["T"],
           },

--- a/next.js
+++ b/next.js
@@ -2,7 +2,6 @@
  * Specific rules for the Pages folder required by Next.js
  */
 module.exports = {
-  extends: ["./react"],
   rules: {
     /**
      ** Import Rules (included in Airbnb-Typescript)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@barnpros/eslint-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An opinionated, sharable ESlint config used across Barn Pros TypeScript and JavaScript applications.",
   "repository": "https://github.com/barnpros/eslint-config-barnpros.git",
   "license": "MIT",


### PR DESCRIPTION
# Fix/ typeParameter Scope

## Summary

typeParameter should be a single string, not string[]. This addresses that. This PR also removes React rules extension from Next.js rules.